### PR TITLE
bug-fix/60-DEP-modeler-allows-incoherent-sequence

### DIFF
--- a/app/lib/olcmodeler/palette/OlcContextPadProvider.js
+++ b/app/lib/olcmodeler/palette/OlcContextPadProvider.js
@@ -56,8 +56,11 @@ OlcContextPadProvider.prototype.getContextPadEntries = function (element) {
         click: removeElement,
         dragstart: removeElement
       }
-    },
-    'connect': {
+    }
+  };
+
+  if (is(element, 'olc:State')) {
+    entries['connect'] = {
       group: 'edit',
       className: 'bpmn-icon-connection',
       title: 'Connect',
@@ -66,9 +69,6 @@ OlcContextPadProvider.prototype.getContextPadEntries = function (element) {
         dragstart: startConnect
       }
     }
-  };
-
-  if (is(element, 'olc:State')) {
     entries['append'] = {
       group: 'create',
       className: 'bpmn-icon-start-event-none',


### PR DESCRIPTION
Fixes #60 

Description: 
- the OLC and DEP context pads now do not offer the option to connectarrrows
- the DEP context pad now does not offer the option to connect an objective that is already a source to another one
- the DEP context pad now does not offer the option to append to an objective that is already a source to another one

## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] the application has been manually tested after merge
- [x] another dev reviewed and approved
- [x] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
