### PR TITLE
Bugfix/82 check conformance of objective objects

### DIFF
--- a/app/lib/mediator/Mediator.js
+++ b/app/lib/mediator/Mediator.js
@@ -141,7 +141,7 @@ Mediator.prototype.addedClass = function (clazz) {
 }
 
 Mediator.prototype.confirmClassDeletion = function (clazz) {
-    const affectedLiterals = this.terminationCondition.modeler.getLiteralsWithClassId(clazz.id);
+    const affectedLiterals = this.terminationConditionModelerHook.modeler.getLiteralsWithClassId(clazz.id);
     const affectedStates = this.olcModelerHook.modeler.getOlcByClass(clazz).get('Elements').filter(element => is(element, 'olc:State'));
     const affectedDataObjectReferences = this.fragmentModelerHook.modeler.getDataObjectReferencesOfClass(clazz);
     const affectedObjects = this.objectiveModelerHook.modeler.getObjectsOfClass(clazz);

--- a/app/lib/objectivemodeler/OmModeler.js
+++ b/app/lib/objectivemodeler/OmModeler.js
@@ -217,33 +217,40 @@ OmModeler.prototype.handleOlcListChanged = function (olcs, dryRun = false) {
 
 OmModeler.prototype.handleStateRenamed = function (olcState) {
     this.getObjectsInState(olcState).forEach((element, gfx) =>
-        this.get('eventBus').fire('element.changed', {
-            element
-        })
+        element.name = `${element.classRef?.name} : ${element.instance?.name}`
     );
+    // This correctly changes the names of all the logical representations of the objects that have to change the name
     this.showObjective(this.getCurrentObjective());
+    // This is needed to update the visual representation of the objects that are currently loaded. Every other visual representation is
+    // non-existing and will therefore be created with the correct properties.
 }
 
 OmModeler.prototype.handleStateDeleted = function (olcState) {
     this.getObjectsInState(olcState).forEach((element, gfx) => {
-        element.businessObject.state = undefined;
-        this.get('eventBus').fire('element.changed', {
-            element
-        });
+        element.state = undefined;
     });
+    // This correctly deletes the state from all the logical representations of the objects that have to lose their state
+    this.showObjective(this.getCurrentObjective());
+    // This is needed to update the visual representation of the objects that are currently loaded. Every other visual representation is
+    // non-existing and will therefore be created with the correct properties.
 }
 
 OmModeler.prototype.handleClassRenamed = function (clazz) {
     this.getObjectsOfClass(clazz).forEach((element, gfx) => {
         element.name = `${element.classRef?.name} : ${element.instance?.name}`
     });
+    // This correctly changes the names of all the logical representations of the objects that have to change the name
     this.showObjective(this.getCurrentObjective());
+    // This is needed to update the visual representation of the objects that are currently loaded. Every other visual representation is
+    // non-existing and will therefore be created with the correct properties.
 }
 
 OmModeler.prototype.handleClassDeleted = function (clazz) {
     this.getObjectsOfClass(clazz).forEach((element, gfx) =>
         this.get('modeling').removeElements([element])
     );
+    // TODO Make this work...
+    // From my Point of View (not necessarily right): This does currently not work because removeElements operates on the visual representation
 }
 
 OmModeler.prototype.getObjectsInState = function (olcState) {
@@ -253,6 +260,7 @@ OmModeler.prototype.getObjectsInState = function (olcState) {
         olcState.id &&
         element.state?.id === olcState.id);
     return objects;
+    // This correctly collects all the logical representations of the objects that have to change the name
 }
 
 OmModeler.prototype.getObjectsOfClass = function (clazz) {
@@ -262,6 +270,7 @@ OmModeler.prototype.getObjectsOfClass = function (clazz) {
         clazz.id &&
         element.classRef?.id === clazz.id);
     return objects;
+    // This correctly collects all the logical representations of the objects that have to change the name
 }
 
 OmModeler.prototype.getObjectInstancesOfClass = function (clazz) {

--- a/app/lib/objectivemodeler/OmModeler.js
+++ b/app/lib/objectivemodeler/OmModeler.js
@@ -221,6 +221,7 @@ OmModeler.prototype.handleStateRenamed = function (olcState) {
             element
         })
     );
+    this.showObjective(this.getCurrentObjective());
 }
 
 OmModeler.prototype.handleStateDeleted = function (olcState) {
@@ -233,11 +234,10 @@ OmModeler.prototype.handleStateDeleted = function (olcState) {
 }
 
 OmModeler.prototype.handleClassRenamed = function (clazz) {
-    this.getObjectsOfClass(clazz).forEach((element, gfx) =>
-        this.get('eventBus').fire('element.changed', {
-            element
-        })
-    );
+    this.getObjectsOfClass(clazz).forEach((element, gfx) => {
+        element.name = `${element.classRef?.name} : ${element.instance?.name}`
+    });
+    this.showObjective(this.getCurrentObjective());
 }
 
 OmModeler.prototype.handleClassDeleted = function (clazz) {
@@ -247,18 +247,21 @@ OmModeler.prototype.handleClassDeleted = function (clazz) {
 }
 
 OmModeler.prototype.getObjectsInState = function (olcState) {
-    return this.get('elementRegistry').filter((element, gfx) =>
+    let objectives = this._definitions.get('rootElements');
+    let objects = objectives.map(objective => objective.get('boardElements')).flat(1).filter((element) =>
         is(element, 'om:Object') &&
-        element.businessObject.state === olcState
-    );
+        olcState.id &&
+        element.state?.id === olcState.id);
+    return objects;
 }
 
 OmModeler.prototype.getObjectsOfClass = function (clazz) {
-    return this.get('elementRegistry').filter((element, gfx) =>
+    let objectives = this._definitions.get('rootElements');
+    let objects = objectives.map(objective => objective.get('boardElements')).flat(1).filter((element) =>
         is(element, 'om:Object') &&
         clazz.id &&
-        element.businessObject.classRef?.id === clazz.id
-    );
+        element.classRef?.id === clazz.id);
+    return objects;
 }
 
 OmModeler.prototype.getObjectInstancesOfClass = function (clazz) {

--- a/app/lib/objectivemodeler/OmModeler.js
+++ b/app/lib/objectivemodeler/OmModeler.js
@@ -254,7 +254,7 @@ OmModeler.prototype.handleClassDeleted = function (clazz) {
     objectives.forEach(objective => {
         let objects = objective.get('boardElements');
         for (var i = 0; i < objects.length; i++) {
-            if (objects[i].classRef === clazz) {
+            if (is(objects[i], 'om:Object') && objects[i].classRef === clazz) {
                 objects.splice(i, 1);
                 i--;
             }
@@ -262,6 +262,7 @@ OmModeler.prototype.handleClassDeleted = function (clazz) {
     })
     this.showObjective(this.getCurrentObjective());
     // This is needed to update the visual representation of the objective that is currently loaded.
+    // This may need to be adapted once the error of links between deleted objects is resolved
 }
 
 OmModeler.prototype.getVisualsInState = function (olcState) {
@@ -271,7 +272,7 @@ OmModeler.prototype.getVisualsInState = function (olcState) {
 }
 
 OmModeler.prototype.getObjectsInState = function (olcState) {
-    let objectives = this._definitions.get('rootElements');
+    let objectives = this.get('rootElements');
     let objects = objectives.map(objective => objective.get('boardElements')).flat(1).filter((element) =>
         is(element, 'om:Object') &&
         olcState.id &&

--- a/app/lib/objectivemodeler/draw/ODRenderer.js
+++ b/app/lib/objectivemodeler/draw/ODRenderer.js
@@ -179,11 +179,7 @@ export default function ODRenderer(
 
   function renderTitelLabel(parentGfx, element) {
     let semantic = getSemantic(element);
-    let text = '';
-    if (semantic.name) {
-      text = semantic.name;
-
-    }
+    let text = `${semantic.classRef?.name} : ${semantic.instance?.name}`;
     renderLabel(parentGfx, text, {
       box: {
         height: 30,


### PR DESCRIPTION
Fixes #82 

Description: We now update the logical representation of every object in every objective and then reload the current objective in order to update the visual representation. When deleting a class we have to update the definitions and therefore cannot really use the getObjectsOfClass() method

## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] the application has been manually tested after merge
- [ ] another dev reviewed and approved
- [x] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
