### PR TITLE
Feature/#90 undefined state for objects 

### DIFF
--- a/app/lib/objectivemodeler/omObjectLabelHandling/OmObjectLabelHandler.js
+++ b/app/lib/objectivemodeler/omObjectLabelHandling/OmObjectLabelHandler.js
@@ -201,7 +201,11 @@ export default class OmObjectLabelHandler extends CommandInterceptor {
 
     updateState(newState, element) {
         const omObject = element.businessObject;
-        omObject.state = newState;
+        if (omObject.state === newState) {
+            omObject.state = undefined;
+        } else {
+            omObject.state = newState;
+        }
         this._eventBus.fire('element.changed', {
             element
         });


### PR DESCRIPTION
Fixes #90

after deselecting the current state of an object, the object is in the "no state" state

## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] the application has been manually tested after merge
- [x] another dev reviewed and approved
- [x] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
