### PR TITLE
label editing in dependency model works again

### DIFF
--- a/app/lib/dependencymodeler/modeling/DepLabelEditing.js
+++ b/app/lib/dependencymodeler/modeling/DepLabelEditing.js
@@ -76,7 +76,7 @@ DepLabelEditing.prototype.activate = function (element) {
 };
 
 DepLabelEditing.prototype.update = function (element, newLabel) {
-    if (element.id !== 'start_state' && event.element.id !== 'final_state') {
+    if (element.id !== 'start_state' && element.id !== 'final_state') {
         this._commandStack.execute('element.updateLabel', {
             element: element,
             newLabel: newLabel


### PR DESCRIPTION
Fixes #109

renaming objectives in the dependency model works without errors again

## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] the application has been manually tested after merge
- [x] another dev reviewed and approved
- [ ] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
