### PR TITLE
Fixes Bug: undefined Elements with dropdown throw errors

### DIFF
--- a/app/lib/fragmentmodeler/modeling/DataObjectLabelHandler.js
+++ b/app/lib/fragmentmodeler/modeling/DataObjectLabelHandler.js
@@ -131,9 +131,6 @@ export default class DataObjectLabelHandler extends CommandInterceptor {
                         this._overlays.remove(this._overlayId);
                         this._overlayId = undefined;
                     }
-                    if (this._currentDropdownTarget?.dataclass === undefined) {
-                        this._modeling.removeElements([this._dropdownContainer.currentElement]);
-                    }
                     this._dropdownContainer.currentElement = undefined;
                     this._currentDropdownTarget = undefined;
                 }

--- a/app/lib/objectivemodeler/omObjectLabelHandling/OmObjectLabelHandler.js
+++ b/app/lib/objectivemodeler/omObjectLabelHandling/OmObjectLabelHandler.js
@@ -161,9 +161,6 @@ export default class OmObjectLabelHandler extends CommandInterceptor {
                         this._overlays.remove(this._overlayId);
                         this._overlayId = undefined;
                     }
-                    if (this._currentDropdownTarget?.classRef === undefined) {
-                        this._modeling.removeElements([this._dropdownContainer.currentElement]);
-                    }
                     this._dropdownContainer.currentElement = undefined;
                     this._currentDropdownTarget = undefined;
                 }


### PR DESCRIPTION
Fixes #111 #98 #101 

Description: changes the behavior by removing the feature that DataObjectReferences and Object without an assigned Dataclass are deleted

## PR checklist

- [ ] dev-branch has been merged into local branch to resolve conflicts
- [ ] the application has been manually tested after merge
- [ ] another dev reviewed and approved
- [ ] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
