### PR TITLE
no error when deleting a class of an object in an objective due to th…

### DIFF
--- a/app/lib/objectivemodeler/OmModeler.js
+++ b/app/lib/objectivemodeler/OmModeler.js
@@ -325,5 +325,5 @@ OmModeler.prototype.isObjectOfDeletedClass = function (clazz, element) {
 }
 
 OmModeler.prototype.isLinkConnectedToObjectOfDeletedClass = function (clazz, element) {
-    return is(element, 'om:Link') && clazz.id && ((element.sourceRef?.classRef.id === clazz.id) || (element.targetRef?.classRef.id === clazz.id));
+    return is(element, 'om:Link') && clazz.id && ((element.sourceRef?.classRef?.id === clazz.id) || (element.targetRef?.classRef?.id === clazz.id));
 }

--- a/app/lib/objectivemodeler/OmModeler.js
+++ b/app/lib/objectivemodeler/OmModeler.js
@@ -254,10 +254,11 @@ OmModeler.prototype.handleClassRenamed = function (clazz) {
 OmModeler.prototype.handleClassDeleted = function (clazz) {
     let objectives = this._definitions.get('rootElements');
     objectives.forEach(objective => {
-        let objects = objective.get('boardElements');
-        for (let i = 0; i < objects.length; i++) {
-            if (is(objects[i], 'om:Object') && clazz.id && objects[i].classRef?.id === clazz.id) {
-                objects.splice(i, 1);
+        let elements = objective.get('boardElements');
+
+        for (let i = 0; i < elements.length; i++) {
+            if (this.isObjectOfDeletedClass(clazz, elements[i]) || this.isLinkConnectedToObjectOfDeletedClass(clazz, elements[i])) {
+                elements.splice(i, 1);
                 i--;
             }
         }
@@ -319,3 +320,10 @@ OmModeler.prototype.getObjectiveByReference = function (objectiveReference) {
     }
 }
 
+OmModeler.prototype.isObjectOfDeletedClass = function (clazz, element) {
+    return is(element, 'om:Object') && clazz.id && element.classRef?.id === clazz.id;
+}
+
+OmModeler.prototype.isLinkConnectedToObjectOfDeletedClass = function (clazz, element) {
+    return is(element, 'om:Link') && clazz.id && ((element.sourceRef?.classRef.id === clazz.id) || (element.targetRef?.classRef.id === clazz.id));
+}


### PR DESCRIPTION
Fixes #100

no error when deleting the class of an object in an objective anymore

## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] the application has been manually tested after merge
- [x] another dev reviewed and approved
- [x] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
