### PR TITLE
Adding role and NoP to fragments

### DIFF
--- a/app/lib/fragmentmodeler/draw/TaskRenderer.js
+++ b/app/lib/fragmentmodeler/draw/TaskRenderer.js
@@ -38,7 +38,6 @@ export default class TaskRenderer extends BaseRenderer {
         return shape;
     }
 
-
     renderEmbeddedDurationLabel(parentGfx, element, align) {
         let semantic = getSemantic(element);
 

--- a/app/lib/fragmentmodeler/draw/TaskRenderer.js
+++ b/app/lib/fragmentmodeler/draw/TaskRenderer.js
@@ -1,11 +1,20 @@
 import BaseRenderer from "diagram-js/lib/draw/BaseRenderer";
 import {is} from "../../util/Util";
 import {assign} from 'min-dash';
-import {getLabelColor, getSemantic} from 'bpmn-js/lib/draw/BpmnRenderUtil';
+import {
+    getCirclePath,
+    getDiamondPath, getFillColor,
+    getLabelColor, getRectPath,
+    getRoundRectPath,
+    getSemantic, getStrokeColor
+} from 'bpmn-js/lib/draw/BpmnRenderUtil';
 import {
     append as svgAppend,
-    classes as svgClasses
+    classes as svgClasses,
+    remove as svgRemove,
+    select as svgSelect
 } from 'tiny-svg';
+import BpmnRenderer from "bpmn-js/lib/draw/BpmnRenderer";
 
 const HIGH_PRIORITY = 1500;
 
@@ -23,9 +32,12 @@ export default class TaskRenderer extends BaseRenderer {
 
     drawShape(parentNode, element) {
         const shape = this.bpmnRenderer.drawShape(parentNode, element);
+        svgRemove(svgSelect(parentNode, '.djs-label'));
         this.renderEmbeddedDurationLabel(parentNode, element, 'right-top');
+        this.renderEmbeddedLabel(parentNode, element, 'center-middle');
         return shape;
     }
+
 
     renderEmbeddedDurationLabel(parentGfx, element, align) {
         let semantic = getSemantic(element);
@@ -40,6 +52,36 @@ export default class TaskRenderer extends BaseRenderer {
             box: element,
             align: align,
             padding: 2,
+            style: {
+                fill: getLabelColor(element)
+            }
+        });
+    }
+
+    renderEmbeddedLabel(parentGfx, element, align) {
+        let semantic = getSemantic(element);
+        var displayedText = "";
+
+        if (semantic.role) {
+            displayedText = displayedText + semantic.role;
+        }
+        if (semantic.NoP) {
+            if (semantic.role) {
+                displayedText = displayedText + " ";
+            }
+            displayedText = displayedText + "(" + semantic.NoP + ")";
+        }
+        if (semantic.name) {
+            if (semantic.role || semantic.NoP) {
+                displayedText = displayedText + "\n: ";
+            }
+            displayedText = displayedText + semantic.name;
+        }
+
+        return this.renderLabel(parentGfx, displayedText, {
+            box: element,
+            align: align,
+            padding: 5,
             style: {
                 fill: getLabelColor(element)
             }


### PR DESCRIPTION
Fixes #132 and #133 

Roles and capacities get now displayed in fragment activities. The style has been adapted according to the POs liking.

## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] the application has been manually tested after merge
- [x] another dev reviewed and approved
- [x] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
