### PR TITLE
allows deselection of selected role and clears NoP in that case

### DIFF
--- a/app/lib/fragmentmodeler/taskLabelHandling/taskLabelHandler.js
+++ b/app/lib/fragmentmodeler/taskLabelHandling/taskLabelHandler.js
@@ -37,6 +37,7 @@ export default class TaskLabelHandler extends CommandInterceptor {
                 this._dropdownContainer.currentElement = element;
 
                 const updateRoleSelection = () => {
+                    //this._rolesDropdown.getEntries().forEach(entry => entry.setSelected(resource.roles?.find(role => role === entry.option)));
                     this._roleDropdown.getEntries().forEach(entry => entry.setSelected(activity.role === entry.option));
                 }
 
@@ -65,6 +66,9 @@ export default class TaskLabelHandler extends CommandInterceptor {
                         this._fragmentModeler._roles || [],
                         (role, element) => {
                             this.updateRole(role, element);
+                            if(element.businessObject.role === undefined){
+                                this._NoPDropdown.clearInput()
+                            }
                             updateRoleSelection();
                         },
                         element
@@ -179,7 +183,13 @@ export default class TaskLabelHandler extends CommandInterceptor {
     }
 
     updateRole(newRole, element) {
-        element.businessObject.role = newRole;
+        const fmObject = element.businessObject;
+        if (fmObject.role === newRole) {
+            fmObject.role = undefined;
+            fmObject.NoP = undefined;
+        } else {
+            fmObject.role = newRole;
+        }
         this._eventBus.fire('element.changed', {
             element
         });

--- a/app/lib/fragmentmodeler/taskLabelHandling/taskLabelHandler.js
+++ b/app/lib/fragmentmodeler/taskLabelHandling/taskLabelHandler.js
@@ -37,7 +37,6 @@ export default class TaskLabelHandler extends CommandInterceptor {
                 this._dropdownContainer.currentElement = element;
 
                 const updateRoleSelection = () => {
-                    //this._rolesDropdown.getEntries().forEach(entry => entry.setSelected(resource.roles?.find(role => role === entry.option)));
                     this._roleDropdown.getEntries().forEach(entry => entry.setSelected(activity.role === entry.option));
                 }
 

--- a/app/lib/fragmentmodeler/taskLabelHandling/taskLabelHandler.js
+++ b/app/lib/fragmentmodeler/taskLabelHandling/taskLabelHandler.js
@@ -108,7 +108,7 @@ export default class TaskLabelHandler extends CommandInterceptor {
                         this.updateRole(newRole,element);
                         populateRoleDropdown();
                     }
-                    if (newNoPInput !== activity.NoP && newNoPInput > 0) {
+                    if (newNoPInput !== activity.NoP && newNoPInput > 0 && activity.role !== undefined) {
                         this.updateNoP(newNoPInput,element);
                         populateNoPDropdown();
                     }


### PR DESCRIPTION
Fixes #208

Description: It is possible to deselect roles for activities in the FM. NoP also gets removed when this happens.

## PR checklist

- [x] dev-branch has been merged into local branch to resolve conflicts
- [x] the application has been manually tested after merge
- [ ] another dev reviewed and approved
- [ ] if feature-Branch: Teams PO has approved (show via e.g. screenshots/screencapture/live demo)
